### PR TITLE
allow to pass the resource directly instead of resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Next up, publish the config file with:
 php artisan vendor:publish --provider="Bolechen\\NovaActivitylog\\ToolServiceProvider" --tag="config"
 ```
 
-And change the resourceName in `config/nova-activitylog.log` to your customize resource name.
+And change the `resource` in `config/nova-activitylog.php` to your custom nova resource.
 
 ## License
 

--- a/config/nova-activitylog.php
+++ b/config/nova-activitylog.php
@@ -11,7 +11,7 @@
 
 return [
     /*
-     * Set the resource used for `nova-activitylog` package. Default is `activitylogs`.
+     * Set the resource used for `nova-activitylog` package.
      */
-    'resourceName' => 'activitylogs',
+    'resource' => \Bolechen\NovaActivitylog\Resources\Activitylog::class,
 ];

--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -2,7 +2,7 @@
     :to="{
         name: 'index',
         params: {
-            resourceName: '{{ config('nova-activitylog.resourceName', 'activitylogs') }}'
+            resourceName: '{{ config('nova-activitylog.resource')::uriKey() }}'
         }
     }"
     tag="h3"

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -47,7 +47,6 @@ class ToolServiceProvider extends ServiceProvider
         Nova::serving(function (ServingNova $event) {
             activity()->enableLogging();
         });
-
     }
 
     /**

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -11,7 +11,6 @@
 
 namespace Bolechen\NovaActivitylog;
 
-use Bolechen\NovaActivitylog\Resources\Activitylog;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nova\Events\ServingNova;
 use Laravel\Nova\Nova;
@@ -24,17 +23,23 @@ class ToolServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->publishes([
+            __DIR__.'/../config/nova-activitylog.php' => config_path('nova-activitylog.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(__DIR__.'/../config/nova-activitylog.php', 'nova-activitylog');
+
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-activitylog');
 
         // 记录操作者 IP
         // @see https://github.com/spatie/laravel-activitylog/issues/39
-        Activity::saving(function (Activity $activity) {
+        config('activitylog.activity_model')::saving(function (Activity $activity) {
             $activity->properties = $activity->properties->put('ip', request()->ip());
         });
 
         $this->app->booted(function () {
             Nova::resources([
-                Activitylog::class,
+                config('nova-activitylog.resource'),
             ]);
             $this->routes();
         });
@@ -43,9 +48,6 @@ class ToolServiceProvider extends ServiceProvider
             activity()->enableLogging();
         });
 
-        $this->publishes([
-            __DIR__.'/../config/nova-activitylog.php' => config_path('nova-activitylog.php'),
-        ], 'config');
     }
 
     /**


### PR DESCRIPTION
Hi instead of 
```php
return [
    'resourceName' => 'activitylogs',
]
```

I have changed it to:

```php
return [
    'resource' => \Bolechen\NovaActivitylog\Resources\Activitylog::class,
]
```

This way you don't have to register your `Activitylog::class` aways regardless if user has provided their own