### PR TITLE
Fix a service provider boot error

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -31,13 +31,13 @@ class ToolServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-activitylog');
 
-        // 记录操作者 IP
-        // @see https://github.com/spatie/laravel-activitylog/issues/39
-        config('activitylog.activity_model')::saving(function (Activity $activity) {
-            $activity->properties = $activity->properties->put('ip', request()->ip());
-        });
-
         $this->app->booted(function () {
+            // 记录操作者 IP
+            // @see https://github.com/spatie/laravel-activitylog/issues/39
+            config('activitylog.activity_model')::saving(function (Activity $activity) {
+                $activity->properties = $activity->properties->put('ip', request()->ip());
+            });
+
             Nova::resources([
                 config('nova-activitylog.resource'),
             ]);


### PR DESCRIPTION
The spatie activity log package was being booted after this package which meant the config values were not available at this point.

``` 
Symfony\Component\Debug\Exception\FatalThrowableError  : Class name must be a valid object or a string

  at /vendor/bolechen/nova-activitylog/src/ToolServiceProvider.php:34
    30|         $this->mergeConfigFrom(__DIR__.'/../config/nova-activitylog.php', 'nova-activitylog');
    31|
    32|         $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-activitylog');
    33|
  > 34|             config('activitylog.activity_model')::saving(function (Activity $activity) {
    35|                 $activity->properties = $activity->properties->put('ip', request()->ip());
    36|             });
    37|         $this->app->booted(function () {
```