### PR TITLE
Add authorization section to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ class NewsItem extends Model
 
 For more advanced usage can look at the doc: https://docs.spatie.be/laravel-activitylog/v3/advanced-usage/logging-model-events
 
+## Authorizing
+
+Typical usage of tool authorizing using `->canSee()` or `->canSeeWhen()` when registering the tool will NOT work. To authorize the tool, simply [make and register a Laravel policy](https://laravel.com/docs/10.x/authorization#creating-policies) for the `ActivityLog` model. If a user is not able to view them according to the policy, the tool will not show.
+
 
 ## Customize
 


### PR DESCRIPTION
I spent a few hours trying to figure out why the tool wouldn't hide using the normal tool authorization, until i found #30 and figured it out. Just wanted to add a section to the documentation to prevent future confusion like mine.