### PR TITLE
Fix 404 error

### DIFF
--- a/src/NovaActivitylog.php
+++ b/src/NovaActivitylog.php
@@ -35,7 +35,6 @@ class NovaActivitylog extends Tool
     public function menu(Request $request)
     {
         return MenuSection::resource(Activitylog::class)
-            ->path('resources/activities')
             ->icon('document-duplicate');
     }
 }


### PR DESCRIPTION
As can be seen in the [docs](https://nova.laravel.com/docs/customization/menus.html#menu-items), MenuSection::resource should not have `->path()` method. This is leading to 404 error. Removing the line fix the 404 error.