### PR TITLE
Move resource registration to Nova serving

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,38 @@
 {
-    "name": "bolechen/nova-activitylog",
-    "description": "A tool to activity logger to monitor the users of your Laravel Nova.",
-    "keywords": [
-        "laravel",
-        "nova",
-        "activity",
-        "log"
-    ],
-    "license": "MIT",
-    "require": {
-        "laravel/nova": "^4.0",
-        "spatie/laravel-activitylog": "^3.9|^4.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Bolechen\\NovaActivitylog\\": "src/"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Bolechen\\NovaActivitylog\\ToolServiceProvider"
-            ]
-        }
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+  "name": "bolechen/nova-activitylog",
+  "description": "A tool to activity logger to monitor the users of your Laravel Nova.",
+  "keywords": [
+    "laravel",
+    "nova",
+    "activity",
+    "log"
+  ],
+  "license": "MIT",
+  "require": {
+    "laravel/nova": "^4.0",
+    "spatie/laravel-activitylog": "^3.9|^4.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Bolechen\\NovaActivitylog\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Bolechen\\NovaActivitylog\\ToolServiceProvider"
+      ]
+    }
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://nova.laravel.com"
+    }
+  ]
 }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -21,7 +21,7 @@ class ToolServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishes([
             __DIR__.'/../config/nova-activitylog.php' => config_path('nova-activitylog.php'),
@@ -37,29 +37,14 @@ class ToolServiceProvider extends ServiceProvider
             config('activitylog.activity_model')::saving(function (Activity $activity) {
                 $activity->properties = $activity->properties->put('ip', request()->ip());
             });
-
-            Nova::resources([
-                config('nova-activitylog.resource'),
-            ]);
-            $this->routes();
         });
 
         Nova::serving(function (ServingNova $event) {
             activity()->enableLogging();
+
+            Nova::resources([
+                config('nova-activitylog.resource'),
+            ]);
         });
-    }
-
-    /**
-     * Register the tool's routes.
-     */
-    protected function routes()
-    {
-    }
-
-    /**
-     * Register any application services.
-     */
-    public function register()
-    {
     }
 }


### PR DESCRIPTION
Nova resources do not get registered when using Octane, see this discussion: https://github.com/laravel/nova-issues/discussions/6458

Also removed empty methods and added the Nova composer repo so that it can be installed standalone.