### PR TITLE
Fix empty ip logs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,38 @@
 {
-    "name": "bolechen/nova-activitylog",
-    "description": "A tool to activity logger to monitor the users of your Laravel Nova.",
-    "keywords": [
-        "laravel",
-        "nova",
-        "activity",
-        "log"
-    ],
-    "license": "MIT",
-    "require": {
-        "laravel/nova": "^4.0",
-        "spatie/laravel-activitylog": "^3.9|^4.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Bolechen\\NovaActivitylog\\": "src/"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Bolechen\\NovaActivitylog\\ToolServiceProvider"
-            ]
-        }
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+  "name": "bolechen/nova-activitylog",
+  "description": "A tool to activity logger to monitor the users of your Laravel Nova.",
+  "keywords": [
+    "laravel",
+    "nova",
+    "activity",
+    "log"
+  ],
+  "license": "MIT",
+  "require": {
+    "laravel/nova": "^4.0",
+    "spatie/laravel-activitylog": "^3.9|^4.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Bolechen\\NovaActivitylog\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Bolechen\\NovaActivitylog\\ToolServiceProvider"
+      ]
+    }
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://nova.laravel.com"
+    }
+  ]
 }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -35,7 +35,11 @@ class ToolServiceProvider extends ServiceProvider
             // 记录操作者 IP
             // @see https://github.com/spatie/laravel-activitylog/issues/39
             config('activitylog.activity_model')::saving(function (Activity $activity) {
-                $activity->properties = $activity->properties->put('ip', request()->ip());
+                $ip = request()->ip();
+
+                if ($ip !== '127.0.0.1') {
+                    $activity->properties = $activity->properties->put('ip', $ip);
+                }
             });
         });
 

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -21,7 +21,7 @@ class ToolServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishes([
             __DIR__.'/../config/nova-activitylog.php' => config_path('nova-activitylog.php'),
@@ -37,29 +37,14 @@ class ToolServiceProvider extends ServiceProvider
             config('activitylog.activity_model')::saving(function (Activity $activity) {
                 $activity->properties = $activity->properties->put('ip', request()->ip());
             });
-
-            Nova::resources([
-                config('nova-activitylog.resource'),
-            ]);
-            $this->routes();
         });
 
         Nova::serving(function (ServingNova $event) {
             activity()->enableLogging();
+
+            Nova::resources([
+                config('nova-activitylog.resource'),
+            ]);
         });
-    }
-
-    /**
-     * Register the tool's routes.
-     */
-    protected function routes()
-    {
-    }
-
-    /**
-     * Register any application services.
-     */
-    public function register()
-    {
     }
 }


### PR DESCRIPTION
This fixes empty logs being added by non-nova actions. The IP will resolve to 127.0.0.1 and an updated log will be created with only this IP.